### PR TITLE
YAML and JSON marshalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.9.5: YAML and JSON unmarshaling
+## 0.9.6: YAML and JSON marshalling
+
+In the previous release we did not consider the need for also marshalling log level values. This release adds the marshalling method to encode log levels to their string representations in YAML and JSON. It also adds the ability to unmarshal from the numeric values should they be present.
+
+## 0.9.5: YAML and JSON unmarshalling
 
 This release fixes the JSON and YAML unmarshalling, so it is compatible with the ContainerSSH 0.3 log format. 
 

--- a/config_test.go
+++ b/config_test.go
@@ -19,6 +19,15 @@ func TestJSONDecode(t *testing.T) {
 	assert.Equal(t, log.FormatText, config.Format)
 }
 
+func TestJSONDecodeNumeric(t *testing.T) {
+	cfg := "{\"level\":7,\"format\":\"text\"}"
+	config := log.Config{}
+	err := json.Unmarshal([]byte(cfg), &config)
+	assert.NoError(t, err)
+	assert.Equal(t, log.LevelDebug, config.Level)
+	assert.Equal(t, log.FormatText, config.Format)
+}
+
 func TestYAMLDecode(t *testing.T) {
 	cfg := "---\nlevel: debug\nformat: text\n"
 	config := log.Config{}
@@ -26,4 +35,43 @@ func TestYAMLDecode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, log.LevelDebug, config.Level)
 	assert.Equal(t, log.FormatText, config.Format)
+}
+
+func TestYAMLDecodeNumeric(t *testing.T) {
+	cfg := "---\nlevel: 7\nformat: text\n"
+	config := log.Config{}
+	err := yaml.Unmarshal([]byte(cfg), &config)
+	assert.NoError(t, err)
+	assert.Equal(t, log.LevelDebug, config.Level)
+	assert.Equal(t, log.FormatText, config.Format)
+}
+
+func TestJSONEncode(t *testing.T) {
+	config := log.Config{
+		Level:  log.LevelDebug,
+		Format: log.FormatText,
+	}
+	jsonData, err := json.Marshal(config)
+	assert.NoError(t, err)
+	rawData := map[string]interface{}{}
+	err = json.Unmarshal(jsonData, &rawData)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "debug", rawData["level"])
+	assert.Equal(t, "text", rawData["format"])
+}
+
+func TestYAMLEncode(t *testing.T) {
+	config := log.Config{
+		Level:  log.LevelDebug,
+		Format: log.FormatText,
+	}
+	jsonData, err := yaml.Marshal(config)
+	assert.NoError(t, err)
+	rawData := map[string]interface{}{}
+	err = yaml.Unmarshal(jsonData, &rawData)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "debug", rawData["level"])
+	assert.Equal(t, "text", rawData["format"])
 }


### PR DESCRIPTION
In the previous release we did not consider the need for also marshalling log level values. This release adds the marshalling method to encode log levels to their string representations in YAML and JSON. It also adds the ability to unmarshal from the numeric values should they be present.